### PR TITLE
Linux relaunch fix

### DIFF
--- a/.changeset/nine-pans-protect.md
+++ b/.changeset/nine-pans-protect.md
@@ -1,0 +1,5 @@
+---
+'@fireblocks/recovery-utility': minor
+---
+
+fix linux appimage relaunch failure

--- a/apps/recovery-utility/main/ipc/useDeployment.ts
+++ b/apps/recovery-utility/main/ipc/useDeployment.ts
@@ -1,12 +1,30 @@
-import { ipcMain } from 'electron';
+import { RelaunchOptions, ipcMain } from 'electron';
 import { app } from 'electron';
+import os from 'os';
 
 import { DeploymentStore } from '../store/deployment';
 import { createWindow } from '../background';
 
 ipcMain.handle('deployment/use', async (event, protocol: 'UTILITY' | 'RELAY') => {
   DeploymentStore.set(protocol);
-  app.relaunch();
+  let opts: RelaunchOptions | undefined;
+  if (os.platform() === 'linux') {
+    /**
+     * On linux we use AppImage, which upon execution mounts the AppImage file onto a directory under /tmp/.mount_xxxxx
+     * When we run the relaunch and exit command it is unmounted.
+     * Subsequent attempts to access anything under the original mount point results in an error.
+     * As such we can't simply use relaunch and exit, we need to extract the AppImage and run it.
+     *
+     * This does not consume additional disk space as as soon as the execution ends, the disk space is freed.
+     */
+    const args = process.argv.slice(1).concat(['--relaunch']);
+    args.unshift('--appimage-extract-and-run');
+    opts = {
+      execPath: process.env.APPIMAGE,
+      args,
+    };
+  }
+  app.relaunch(opts);
   app.exit();
   await createWindow();
 });

--- a/apps/recovery-utility/main/store/deployment.ts
+++ b/apps/recovery-utility/main/store/deployment.ts
@@ -1,4 +1,5 @@
 import Store from 'electron-store';
+import os from 'os';
 
 export const PROTOCOLS = {
   UTILITY: {
@@ -35,8 +36,10 @@ export class DeploymentStore {
   }
 
   public static set(protocol: 'UTILITY' | 'RELAY' | null) {
+    // Due to comment under useDeployment.ts for linux, we give linux 1 minute for the mode timeout instead of 15 seconds.
+    const expTimeout = os.platform() === 'linux' ? 60_000 : 15_000;
     DeploymentStore._store.set('protocol', protocol);
-    DeploymentStore._store.set('exp', Date.now() + 15000); // 15 seconds
+    DeploymentStore._store.set('exp', Date.now() + expTimeout); // 15 seconds
   }
 
   public static reset() {


### PR DESCRIPTION
# Description

Fixes issue #58 
On linux we use AppImage, which upon execution mounts the AppImage file onto a directory under /tmp/.mount_xxxxx
When we run the relaunch and exit command it is unmounted.
Subsequent attempts to access anything under the original mount point results in an error.
As such we can't simply use relaunch and exit, we need to extract the AppImage and run it.
This does not consume additional disk space as as soon as the execution ends, the disk space is freed.

# Pinpointed Tests

Please describe the specific tests done for the bug you fixed?
Tested on linux machine to verify issue no longer occurs.

Did you replicate the issue and verify it is no longer occurring? Yes

Any additional tests done?

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] I have verified that the project builds (using `yarn build`)
- [ ] E2E Tests finish successfully for all relevant assets
